### PR TITLE
fixed #18 ビルドキャッシュ

### DIFF
--- a/codebuild.tf
+++ b/codebuild.tf
@@ -1,13 +1,15 @@
 module "codebuild_staging" {
-  source           = "./modules/codebuild"
-  stage            = "staging"
-  bucket_name      = "staging-twitter-counter-api"
-  service_role_arn = aws_iam_role.codebuild_service_role.arn
+  source            = "./modules/codebuild"
+  stage             = "staging"
+  bucket_name       = "staging-twitter-counter-api"
+  cache_bucket_name = aws_s3_bucket.build_cache.bucket
+  service_role_arn  = aws_iam_role.codebuild_service_role.arn
 }
 
 module "codebuild_production" {
-  source           = "./modules/codebuild"
-  stage            = "production"
-  bucket_name      = "twitter-counter-api"
-  service_role_arn = aws_iam_role.codebuild_service_role.arn
+  source            = "./modules/codebuild"
+  stage             = "production"
+  bucket_name       = "twitter-counter-api"
+  cache_bucket_name = aws_s3_bucket.build_cache.bucket
+  service_role_arn  = aws_iam_role.codebuild_service_role.arn
 }

--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -6,6 +6,8 @@ variable "bucket_name" {
   default = "dev-twitter-counter-api"
   description = "staging or production"
 }
+variable "cache_bucket_name" {
+}
 variable "service_role_arn" {
 }
 
@@ -16,6 +18,11 @@ resource "aws_codebuild_project" "default" {
 
   artifacts {
     type = "CODEPIPELINE"
+  }
+
+  cache {
+    type     = "S3"
+    location = var.cache_bucket_name
   }
 
   environment {

--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,11 @@
 resource "aws_s3_bucket" "pipeline" {
   bucket        = "twitter-counter-api-deploy-pipeline-artifacts"
   acl           = "private"
-  force_destroy = false
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "build_cache" {
+  bucket        = "twitter-counter-api-deploy-pipeline-caches"
+  acl           = "private"
+  force_destroy = true
 }


### PR DESCRIPTION
/root/.composer、/root/.npm をキャッシュすることで
11分半かかっていたビルド・デプロイが6分半になった